### PR TITLE
add link to k8s-docs about: annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -468,6 +468,7 @@ The following are primarily links to either the 'concepts' or 'tasks' section of
 
 ## Pod Design
 - [Concepts -> Assign Pods to Nodes - Selectors](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/)
+- [Concepts -> Annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/)
 - [Concepts -> Labels and Selectors](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/)
 - [Tasks -> ReplicaSet Rolling Updates](https://kubernetes.io/docs/tasks/run-application/run-stateless-application-deployment/)
 - [Concepts -> Deployments, Rollouts, and Rollbacks](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/)


### PR DESCRIPTION
There is an objective: Pod Design > Understand how to use Labels, Selectors, and Annotations
But there was no link yet to any page about Annotations.