### PR TITLE
Added link to CKAD practice challenges on Katacoda.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ List of resources and notes for passing the Certified Kubernetes Application Dev
 - [CNCF Official CKAD Candidate Handbook](https://www.cncf.io/certification/candidate-handbook)
 - [VIM Cheatsheet - You should know VIM pretty well](https://devhints.io/vim)
 - [Excellent CKAD Exercises to complement this guide](https://github.com/dgkanatsios/CKAD-exercises)
+- [More CKAD Practice Questions](https://dev.to/liptanbiswas/ckad-practice-questions-4mpn)
 - [TMUX Cheat Sheet - TMUX is useful, especially for CKA](https://gist.github.com/MohamedAlaa/2961058)
 
 


### PR DESCRIPTION
A set of practice challenges to prepare for the CNCF Certified Kubernetes Application Developer exam built using Katacoda in already provisioned and running Kubernetes cluster. Tests have verifications in place as well.

PS: They are authored by me.